### PR TITLE
two small changes to get it installed in a up to date clean python environment

### DIFF
--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -99,7 +99,7 @@ def process(parser, cmd_args, widget_dict, use_argparse_groups):
 
     return list(categorize(required_actions, cmd_args, widget_dict, required=True)) + \
            list(categorize(optional_actions, cmd_args, widget_dict)) + \
-           map(build_radio_group, mutually_exclusive_groups)
+           list(map(build_radio_group, mutually_exclusive_groups))
 
 def process_action_group(action_group, cmd_args, widget_dict):
   mutually_exclusive_groups = [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
                  'application with one line'),
     license='MIT',
     packages=find_packages(),
-    install_requires=deps,
+#    install_requires=deps,
     include_package_data=True,
     dependency_links = ["http://www.wxpython.org/download.php"],
     classifiers = [


### PR DESCRIPTION
the download of wxpython4 beta is not necessary anymore (and produces in error messages)
python3 map to list is added